### PR TITLE
调整Clean与Reset的先后顺序

### DIFF
--- a/git.go
+++ b/git.go
@@ -220,13 +220,13 @@ func (c *GitClient) Reset(opts ...GitResetOption) (err error) {
 		return err
 	}
 
-	// reset
-	if err := wt.Reset(o); err != nil {
+	// clean
+	if err := wt.Clean(&git.CleanOptions{Dir: true}); err != nil {
 		return err
 	}
 
-	// clean
-	if err := wt.Clean(&git.CleanOptions{Dir: true}); err != nil {
+	// reset
+	if err := wt.Reset(o); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
目前项目Reset后 会生成临时文件 导致无法clean
现在调整先clean后reset 这样能够避免reset生成的临时文件阻止流程进行